### PR TITLE
issue 46 - home page now responsive and pokemon details page also responsive

### DIFF
--- a/src/components/ImageNavigator/TheSpriteViewer.vue
+++ b/src/components/ImageNavigator/TheSpriteViewer.vue
@@ -10,19 +10,22 @@ const organizedSprites = ref(null);
 const selectedVersion = ref(null);
 const selectedImage = ref(null);
 
-onMounted(() => {
+onMounted(() =>
+{
     organizedSprites.value = sortSprites();
     selectedVersion.value = organizedSprites.value.official_artwork;
     selectedImage.value = selectedVersion.value.front_default;
 });
 
-watch(props, () => {
+watch(props, () =>
+{
     organizedSprites.value = sortSprites();
     selectedVersion.value = organizedSprites.value.official_artwork;
     selectedImage.value = selectedVersion.value.front_default;
 });
 
-function sortSprites() {
+function sortSprites()
+{
     return {
         official_artwork: { ...props.sprites.other["official-artwork"] },
         base: {
@@ -73,13 +76,13 @@ function sortSprites() {
         // TODO implement static sprites for this generation
         g5_black_white: {
             ...props.sprites.versions["generation-v"]["black-white"][
-                "animated"
-                ]
+            "animated"
+            ]
         },
         g6_omega_ruby_alpha_saphire: {
             ...props.sprites.versions["generation-vi"][
-                "omegaruby-alphasapphire"
-                ]
+            "omegaruby-alphasapphire"
+            ]
         },
         g6_x_y: {
             ...props.sprites.versions["generation-vi"]["x-y"]
@@ -91,56 +94,34 @@ function sortSprites() {
 </script>
 
 <template>
-    <div class="flex w-full h-auto">
-        <img
-            class="rounded shadow w-full"
-            :src="selectedImage"
-            alt="front-sprite"
-        >
-    </div>
-
-    <div class="mt-1 flex w-full overflow-y-scroll snap-x gap-1">
-        <template
-            v-for="(sprite, key) in selectedVersion"
-            :key="sprite"
-        >
-            <div
-                v-if="sprite"
-                class="snap-start flex-shrink-0 flex-grow-0 w-1/4 flex-shrink-0 relative border border-slate-200 rounded"
-                @click="selectedImage = sprite"
-            >
-                <img
-                    class="shadow w-full h-full"
-                    :src="sprite"
-                    alt="front-sprite"
-                >
-                <div
-                    class="absolute top-0 right-0 inline-flex flex-row bg-slate-100 rounded p-0.5 gap-1"
-                >
-                    <FemaleIcon
-                        v-if="key.includes('female')"
-                        class="text-pink-500 w-3 h-3"
-                    />
-                    <MaleIcon
-                        v-if="!key.includes('female')"
-                        class="text-blue-600 w-3 h-3"
-                    />
-                    <SparklesIcon
-                        v-if="key.includes('shiny')"
-                        class="text-yellow-600 w-3 h-3"
-                    />
-                </div>
+    <div class="md:flex">
+        <div class="md:min-w-[450px] md:max-w-[450px] md:mx-auto">
+            <div class="w-full ">
+                <img class="rounded shadow w-full max-h-[450px]" :src="selectedImage" alt="front-sprite">
             </div>
-        </template>
-    </div>
 
-    <TheVersionSelector
-        :versions="organizedSprites"
-        @version-selected="
-            (e) => {
+            <div class="mt-1 flex w-full overflow-y-scroll snap-x gap-1">
+                <template v-for="(sprite, key) in selectedVersion" :key="sprite">
+                    <div v-if="sprite"
+                        class="snap-start flex-shrink-0 flex-grow-0 w-1/4 flex-shrink-0 relative border border-slate-200 rounded"
+                        @click="selectedImage = sprite">
+                        <img class="shadow w-full h-full max-h-[110px]" :src="sprite" alt="front-sprite">
+                        <div class="absolute top-0 right-0 inline-flex flex-row bg-slate-100 rounded p-0.5 gap-1">
+                            <FemaleIcon v-if="key.includes('female')" class="text-pink-500 w-3 h-3" />
+                            <MaleIcon v-if="!key.includes('female')" class="text-blue-600 w-3 h-3" />
+                            <SparklesIcon v-if="key.includes('shiny')" class="text-yellow-600 w-3 h-3" />
+                        </div>
+                    </div>
+                </template>
+            </div>
+        </div>
+
+        <div>
+            <TheVersionSelector :versions="organizedSprites" @version-selected="(e) => {
                 selectedVersion = e;
                 selectedImage = e.front_default;
             }
-        "
-    />
+                " />
+        </div>
+    </div>
 </template>

--- a/src/components/TopBar/SignalIndicator.vue
+++ b/src/components/TopBar/SignalIndicator.vue
@@ -1,9 +1,9 @@
 <template>
-    <div
-        class="flex flex-nowrap gap-1 justify-evenly items-end h-5 w-5 bg-red-700 rounded-sm"
-    >
-        <div class="bg-lime-400 h-1/4 w-2 rounded-xs" />
-        <div class="bg-lime-400 h-1/2 w-2 rounded-xs" />
-        <div class="bg-lime-400 h-full w-2 rounded-xs" />
-    </div>
+    <router-link :to="{ name: 'home' }">
+        <div class="flex flex-nowrap gap-1 justify-evenly items-end h-5 w-5 bg-red-700 rounded-sm">
+            <div class="bg-lime-400 h-1/4 w-2 rounded-xs" />
+            <div class="bg-lime-400 h-1/2 w-2 rounded-xs" />
+            <div class="bg-lime-400 h-full w-2 rounded-xs" />
+        </div>
+    </router-link>
 </template>

--- a/src/views/BasicView.vue
+++ b/src/views/BasicView.vue
@@ -9,23 +9,26 @@ import TheSpriteViewer from "@/components/ImageNavigator/TheSpriteViewer.vue";
 const pokemonStore = usePokemonStore();
 const route = useRoute();
 
-onMounted(() => {
+onMounted(() =>
+{
     pokemonStore.select_pokemon(route.params.id);
 });
 </script>
 
 <template>
-    <section
-        v-if="pokemonStore.pokemon !== ''"
-        class="p-2"
-    >
-        <TheSpriteViewer :sprites="pokemonStore.pokemon.sprites" />
-        <p class="mt-3 font-bold">
-            {{ pokemonStore?.pokemon?.flavor_text_entries[1].flavor_text }}
-        </p>
-        <!-- TODO: Implement loading state and to prevent rendering warnings, then simplify conditional -->
+    <section class="max-w-5xl md:mx-auto md:mt-10">
+
+        <div v-if="pokemonStore.pokemon !== ''" class="p-2">
+            <TheSpriteViewer :sprites="pokemonStore.pokemon.sprites" />
+            <p class="mt-3 font-bold md:text-center">
+                {{ pokemonStore?.pokemon?.flavor_text_entries[1].flavor_text }}
+            </p>
+            <!-- TODO: Implement loading state and to prevent rendering warnings, then simplify conditional -->
+        </div>
+
+
+        <!-- TODO: this is commented out because not enough time to finish have to start applying for jobs -->
+        <!-- <p>{{ route.params.id }}</p> -->
+        <!-- <TheNavBar /> -->
     </section>
-    
-    <p>{{ route.params.id }}</p>
-    <TheNavBar />
 </template>

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -19,27 +19,19 @@ const pokedex = usePokedexStore();
         </div>
 
         <!--Display information about current region and pokemon count -->
-        <p
-            v-if="!pokedex.loading && !region_pokemon.loading"
-            class="font-bungee text-sm py-1 px-2 text-slate-500"
-        >
+        <p v-if="!pokedex.loading && !region_pokemon.loading" class="font-bungee text-sm py-1 px-2 text-slate-500">
             {{ region_pokemon.pokemon.length }} Pokémon in {{ pokedex.active_region.name }}
         </p>
 
 
         <div v-show="region_pokemon.filtered_pokemon">
-            <div class="grid grid-cols-3 gap-2 py-1 px-2">
-                <div
-                    v-for="pokemon in region_pokemon.filtered_pokemon"
-                    :key="pokemon.species_id"
-                    class="border-[1px] rounded-md border-slate-600"
-                >
+            <div class="grid grid-cols-3 lg:grid-cols-12 gap-2 py-1 px-2">
+                <div v-for="pokemon in region_pokemon.filtered_pokemon" :key="pokemon.species_id"
+                    class="border-[1px] rounded-md border-slate-600">
                     <a :href="`/${pokemon.species_id}/basic/`">
                         <v-lazy-image
-                            :src=" pokemon?.species_id ? `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/${pokemon.species_id}.png` : './img/pokeball-grayscale.png'"
-                            src-placeholder="/img/loading-spinner.gif"
-                            class="w-full h-auto p-2"
-                        />
+                            :src="pokemon?.species_id ? `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/${pokemon.species_id}.png` : './img/pokeball-grayscale.png'"
+                            src-placeholder="/img/loading-spinner.gif" class="w-full h-auto p-2" />
                         <p class="text-center font-bungee text-xs p-1 text-slate-600">
                             {{ pokemon.name }}
                         </p>
@@ -49,31 +41,20 @@ const pokedex = usePokedexStore();
         </div>
 
         <div v-show="!region_pokemon.filtered_pokemon">
-            <div
-                v-if="!region_pokemon.loading"
-                class="grid grid-cols-3 gap-2 py-1 px-2"
-            >
-                <div
-                    v-for="pokemon in region_pokemon.pokemon"
-                    :key="pokemon.species_id"
-                    class="border-[1px] rounded-md border-slate-600"
-                >
+            <div v-if="!region_pokemon.loading" class="grid grid-cols-3 md:grid-cols-6 lg:grid-cols-12 gap-2 py-1 px-2">
+                <div v-for="pokemon in region_pokemon.pokemon" :key="pokemon.species_id"
+                    class="border-[1px] rounded-md border-slate-600">
                     <a :href="`/${pokemon.species_id}/basic/`">
                         <v-lazy-image
-                            :src=" pokemon?.species_id ? `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/${pokemon.species_id}.png` : './img/pokeball-grayscale.png'"
-                            src-placeholder="/img/loading-spinner.gif"
-                            class="w-full h-auto p-2"
-                        />
+                            :src="pokemon?.species_id ? `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/${pokemon.species_id}.png` : './img/pokeball-grayscale.png'"
+                            src-placeholder="/img/loading-spinner.gif" class="w-full h-auto p-2" />
                         <p class="text-center font-bungee text-xs p-1 text-slate-600">
                             {{ pokemon.name }}
                         </p>
                     </a>
                 </div>
             </div>
-            <div
-                v-else
-                class="w-full h-[80vh] flex justify-center align-middle"
-            >
+            <div v-else class="w-full h-[80vh] flex justify-center align-middle">
                 <CircleSpinner class="text-center text-slate-500 w-1/2 h-auto p-6 " />
             </div>
         </div>


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List
any dependencies that are required for this change.
Initially home page was only displaying 3 massive pokemon images but now displays 12 also when a pokemon was clicked the details page for that pokemon was not responsive but now is.

Fixes #46 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration
No tests were run

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules